### PR TITLE
HotFix of OutputFile::getProgressDuration()

### DIFF
--- a/src/AvTranscoder/file/OutputFile.hpp
+++ b/src/AvTranscoder/file/OutputFile.hpp
@@ -109,7 +109,7 @@ public:
 
 	virtual void setVerbose( bool verbose = false ){ _verbose = verbose; }
 	
-	double getProgressDuration();
+	virtual double getProgressDuration();
 
 private:
 	std::vector<AvOutputStream*> _outputStreams;


### PR DESCRIPTION
Make this method virtual, as others in OutputFile, to override it
