### PR TITLE
Clean use of av_strerror

### DIFF
--- a/src/AvTranscoder/essenceStream/AvInputAudio.cpp
+++ b/src/AvTranscoder/essenceStream/AvInputAudio.cpp
@@ -59,13 +59,13 @@ void AvInputAudio::setup()
 		msg +=  avCodec->long_name;
 		msg += " (";
 		msg += avCodec->name;
-		msg += ")";
+		msg += ") ";
 		avcodec_close( avCodecContext );
 
-		char err[250];
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( ret, err, sizeof(err) );
+		msg += err;
 
-		av_strerror( ret, err, 250 );
-		std::cout << err << std::endl;
 		throw std::runtime_error( msg );
 	}
 
@@ -173,12 +173,10 @@ bool AvInputAudio::decodeNextFrame()
 		packet.size         = data.getSize();
 		
 		int ret = avcodec_decode_audio4( _codec->getAVCodecContext(), _frame, &got_frame, &packet );
-
 		if( ret < 0 )
 		{
-			char err[250];
-			av_strerror( ret, err, 250 );
-			
+			char err[AV_ERROR_MAX_STRING_SIZE];
+			av_strerror( ret, err, sizeof(err) );
 			throw std::runtime_error( "an error occured during audio decoding" + std::string( err ) );
 		}
 

--- a/src/AvTranscoder/essenceStream/AvInputVideo.cpp
+++ b/src/AvTranscoder/essenceStream/AvInputVideo.cpp
@@ -119,9 +119,8 @@ bool AvInputVideo::decodeNextFrame()
 		int ret = avcodec_decode_video2( _codec->getAVCodecContext(), _frame, &got_frame, &packet );
 		if( ret < 0 )
 		{
-			char err[250];
-			av_strerror( ret, err, 250);
-			
+			char err[AV_ERROR_MAX_STRING_SIZE];
+			av_strerror( ret, err, sizeof(err) );
 			throw std::runtime_error( "an error occured during video decoding - " + std::string(err) );
 		}
 		av_free_packet( &packet );

--- a/src/AvTranscoder/essenceStream/AvOutputAudio.cpp
+++ b/src/AvTranscoder/essenceStream/AvOutputAudio.cpp
@@ -34,8 +34,8 @@ void AvOutputAudio::setup()
 	int ret = avcodec_open2( codecContext, _codec.getAVCodec(), NULL );
 	if( ret < 0 )
 	{
-		char err[250];
-		av_strerror( ret, err, 250);
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( ret, err, sizeof(err) );
 		std::string msg = "could not open audio encoder: ";
 		msg += err;
 		throw std::runtime_error( msg );
@@ -69,18 +69,16 @@ bool AvOutputAudio::encodeFrame( const Frame& sourceFrame, Frame& codedFrame )
 	int buffer_size = av_samples_get_buffer_size( NULL, codecContext->channels, frame->nb_samples, codecContext->sample_fmt, 0 );
 	if( buffer_size < 0 )
 	{
-		char err[250];
-		av_strerror( buffer_size, err, 250 );
-		
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( buffer_size, err, sizeof(err) );
 		throw std::runtime_error( "EncodeFrame error: buffer size < 0 - " + std::string(err) );
 	}
 
 	int retvalue = avcodec_fill_audio_frame( frame, codecContext->channels, codecContext->sample_fmt, sourceAudioFrame.getPtr(), buffer_size, 0 );
 	if( retvalue < 0 )
 	{
-		char err[250];
-		av_strerror( retvalue, err, 250);	
-		
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( retvalue, err, sizeof(err) );
 		throw std::runtime_error( "EncodeFrame error: avcodec fill audio frame - " + std::string( err ) );
 	}
 	

--- a/src/AvTranscoder/essenceStream/AvOutputVideo.cpp
+++ b/src/AvTranscoder/essenceStream/AvOutputVideo.cpp
@@ -35,8 +35,8 @@ void AvOutputVideo::setup( )
 	int ret = avcodec_open2( codecContext, _codec.getAVCodec(), NULL );
 	if( ret < 0 )
 	{
-		char err[250];
-		av_strerror( ret, err, 250);
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( ret, err, sizeof(err) );
 		std::string msg = "could not open video encoder: ";
 		msg += err;
 		throw std::runtime_error( msg );

--- a/src/AvTranscoder/file/OutputFile.cpp
+++ b/src/AvTranscoder/file/OutputFile.cpp
@@ -136,8 +136,8 @@ bool OutputFile::beginWrap( )
 	int ret = avformat_write_header( _formatContext, NULL );
 	if( ret != 0 )
 	{
-		char err[250];
-		av_strerror( ret, err, 250);
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( ret, err, sizeof(err) );
 		std::string msg = "could not write header: ";
 		msg += err;
 		throw std::runtime_error( msg );
@@ -170,8 +170,8 @@ IOutputStream::EWrappingStatus OutputFile::wrap( const CodedData& data, const si
 
 	if( ret != 0 )
 	{
-		char err[250];
-		av_strerror( ret, err, 250);
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( ret, err, sizeof(err) );
 		std::string msg = "error when writting packet in stream: ";
 		msg += err;
 		// throw std::runtime_error( msg );
@@ -229,8 +229,8 @@ void OutputFile::addMetadata( const std::string& key, const std::string& value )
 	int ret = av_dict_set( &_formatContext->metadata, key.c_str(), value.c_str(), 0 );
 	if( ret < 0 )
 	{
-		char err[250];
-		av_strerror( ret, err, 250 );
+		char err[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror( ret, err, sizeof(err) );
 		std::cout << err << std::endl;
 	}
 }

--- a/src/AvTranscoder/option/Option.cpp
+++ b/src/AvTranscoder/option/Option.cpp
@@ -98,7 +98,7 @@ void Option::setFlag( const std::string& flag, const bool enable )
 	if( error )
 	{
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "unknown key " + getName() + ": " + err );
 	}
 
@@ -111,7 +111,7 @@ void Option::setFlag( const std::string& flag, const bool enable )
 	if( error )
 	{
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "setting " + getName() + " parameter to " + flag + ": " + err );
 	}
 }
@@ -122,7 +122,7 @@ void Option::setBool( const bool value )
 	if( error )
 	{
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "setting " + getName() + " parameter to " + ( value ? "true" : "false" ) + ": " + err );
 	}
 }
@@ -135,7 +135,7 @@ void Option::setInt( const int value )
 		std::ostringstream os;
 		os << value;
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "setting " + getName() + " parameter to " + os.str() + ": " + err );
 	}
 }
@@ -151,7 +151,7 @@ void Option::setRatio( const int num, const int den )
 		std::ostringstream os;
 		os << num << "/" << den;
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "setting " + getName() + " parameter to " + os.str() + ": " + err );
 	}
 }
@@ -164,7 +164,7 @@ void Option::setDouble( const double value )
 		std::ostringstream os;
 		os << value;
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "setting " + getName() + " parameter to " + os.str() + ": " + err );
 	}
 }
@@ -175,7 +175,7 @@ void Option::setString( const std::string& value )
 	if( error )
 	{
 		char err[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror( error, err, AV_ERROR_MAX_STRING_SIZE );
+		av_strerror( error, err, sizeof(err) );
 		throw std::runtime_error( "setting " + getName() + " parameter to " + value + ": " + err );
 	}
 }


### PR DESCRIPTION
- Use macro AV_ERROR_MAX_STRING_SIZE.
- Get size of errbuf with sizeof array.
