### PR TITLE
AvInputStream: use std::queue instead of std::vector for stream cache

### DIFF
--- a/src/AvTranscoder/codedStream/AvInputStream.cpp
+++ b/src/AvTranscoder/codedStream/AvInputStream.cpp
@@ -76,7 +76,7 @@ bool AvInputStream::readNextPacket( CodedData& data )
 	if( ! _streamCache.empty() )
 	{
 		_streamCache.front().getBuffer().swap( data.getBuffer() );
-		_streamCache.erase( _streamCache.begin() );
+		_streamCache.pop();
 	}
 	// else read next packet
 	else
@@ -94,7 +94,7 @@ void AvInputStream::addPacket( AVPacket& packet )
 		return;
 
 	CodedData data;
-	_streamCache.push_back( data );
+	_streamCache.push( data );
 	_streamCache.back().getBuffer().resize( packet.size );
 	if( packet.size != 0 )
 		memcpy( _streamCache.back().getPtr(), packet.data, packet.size );
@@ -148,7 +148,7 @@ double AvInputStream::getDuration() const
 
 void AvInputStream::clearBuffering()
 {
-	_streamCache.clear();
+	_streamCache = std::queue<CodedData>();
 }
 
 AVStream* AvInputStream::getAVStream() const

--- a/src/AvTranscoder/codedStream/AvInputStream.hpp
+++ b/src/AvTranscoder/codedStream/AvInputStream.hpp
@@ -3,6 +3,8 @@
 
 #include "IInputStream.hpp"
 
+#include <queue>
+
 struct AVStream;
 
 namespace avtranscoder
@@ -45,7 +47,7 @@ private:
 	InputFile* _inputFile;  ///< Has link (no ownership)
 	ICodec* _codec;  ///< Has ownership
 
-	std::vector<CodedData> _streamCache;
+	std::queue<CodedData> _streamCache;
 
 	size_t _streamIndex;  ///<  Index of the stream in the input file
 	bool _bufferized;  ///< If the stream is bufferized


### PR DESCRIPTION
Following PR #14
