### PR TITLE
Transcoder: fix progression computing

### DIFF
--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -301,7 +301,8 @@ void Transcoder::process( IProgress& progress )
 
 		frameProcessed =  processFrame();
 
-		if( progress.progress( _outputFile.getProgressDuration(), totalDuration ) == eJobStatusCancel )
+		double progressDuration = _outputFile.getProgressDuration();
+		if( progress.progress( ( progressDuration > totalDuration )? totalDuration : progressDuration, totalDuration ) == eJobStatusCancel )
 			break;
 
 		++frame;


### PR DESCRIPTION
Avoid floating precision errors at the end of the process, so that progress never exceeds max duration
