### PR TITLE
ProfileLoader: add a default profiles location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ add_definitions(-DAVTRANSCODER_VERSION_MAJOR=${AVTRANSCODER_VERSION_MAJOR})
 add_definitions(-DAVTRANSCODER_VERSION_MINOR=${AVTRANSCODER_VERSION_MINOR})
 add_definitions(-DAVTRANSCODER_VERSION_MICRO=${AVTRANSCODER_VERSION_MICRO})
 
+# Define AvTranscoder default path to profiles
+add_definitions(-DAVTRANSCODER_DEFAULT_AVPROFILES="${CMAKE_INSTALL_PREFIX}/share/ressource")
+
 # Diplay commands being ran by CMake
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 

--- a/src/AvTranscoder/ProfileLoader.cpp
+++ b/src/AvTranscoder/ProfileLoader.cpp
@@ -40,10 +40,12 @@ void ProfileLoader::loadProfiles( const std::string& avProfilesPath )
 	std::string realAvProfilesPath = avProfilesPath;
 	if( realAvProfilesPath.empty() )
 	{
+		// get custom profiles location from AVPROFILES environment variable
 		if( std::getenv( "AVPROFILES" ) )
 			realAvProfilesPath = std::getenv( "AVPROFILES" );
+		// else get default profiles location
 		else
-			return;
+			realAvProfilesPath = AVTRANSCODER_DEFAULT_AVPROFILES;
 	}
 	
 	std::vector< std::string > paths;


### PR DESCRIPTION
* Used if AVPROFILES environment variable is not set.
* Fix #85

<!---
@huboard:{"order":90.0,"milestone_order":10.875,"custom_state":""}
-->
