### PR TITLE
Logger: fix build on Windows

### DIFF
--- a/src/AvTranscoder/log.cpp
+++ b/src/AvTranscoder/log.cpp
@@ -12,12 +12,10 @@ void callbackToWriteInFile( void *ptr, int level, const char *fmt, va_list vl )
 
 	// Print line in log file
 	std::ofstream outputFile;
-	outputFile.open( Logger::getLogFileName().c_str(), std::ios::out | std::ios::app );
+	outputFile.open( LOG_FILE, std::ios::out | std::ios::app );
 	outputFile << line;
 	outputFile.close();
 }
-
-std::string Logger::_logFileName( "avtranscoder.log" );
 
 void Logger::setLogLevel( const int level )
 {
@@ -60,7 +58,7 @@ void Logger::logInFile()
 
 	// clean log file
 	std::ofstream outputFile;
-	outputFile.open( Logger::getLogFileName().c_str() );
+	outputFile.open( LOG_FILE );
 	outputFile.close();
 }
 

--- a/src/AvTranscoder/log.hpp
+++ b/src/AvTranscoder/log.hpp
@@ -13,6 +13,7 @@ extern "C" {
 namespace avtranscoder
 {
 
+#define LOG_FILE "avtranscoder.log"
 #define LOG_DEBUG( ... ) { std::stringstream os; os << __VA_ARGS__; Logger::log( AV_LOG_DEBUG, os.str() ); }
 #define LOG_INFO( ... ) { std::stringstream os; os << __VA_ARGS__; Logger::log( AV_LOG_INFO, os.str() ); }
 #define LOG_WARN( ... ) { std::stringstream os; os << __VA_ARGS__; Logger::log( AV_LOG_WARNING, os.str() ); }
@@ -31,7 +32,7 @@ public:
 
 	/**
 	 * @brief Log with the ffmpeg/libav log system
-	 * @note use define LOG_* to log at DEBUG/INFO/WARN/ERROR level
+	 * @note you can use macro LOG_* to log at DEBUG/INFO/WARN/ERROR level
 	 * @param msg: the message will be prefixed by '[avTranscoder - <level>]'
 	 * @param msg: the message will be suffixed by '\n'
 	 */
@@ -39,20 +40,9 @@ public:
 
 	/**
 	 * @brief Log ffmpeg/libav and avtranscoder informations in a text file.
-	 * @note Default log filename is avtranscoder.log
-	 * @see getLogFileName
-	 * @see setLogFileName
+	 * @note log filename is avtranscoder.log
 	 */
 	static void logInFile();
-
-	///@{
-	/// @warning Need to set the expected log filename before calling logInFile
-	static std::string& getLogFileName() { return _logFileName; }
-	static void setLogFileName( const std::string& newLogFileName ) { _logFileName = newLogFileName; }
-	///@}
-
-private:
-	static std::string _logFileName;  ///< Name of the log file
 };
 
 }


### PR DESCRIPTION
* Remove static attribute _logFileName because of a link error with
Microsoft Compiler (MSVC).
* Currently the log file is named avtranscoder.log