### PR TITLE
MediaProperties: when bitRate is unknown, compute it

### DIFF
--- a/src/AvTranscoder/mediaProperty/AudioProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/AudioProperties.cpp
@@ -157,9 +157,14 @@ size_t AudioProperties::getBitRate() const
 {
 	if( ! _codecContext )
 		throw std::runtime_error( "unknown codec context" );
-	int bitsPerSample = av_get_bits_per_sample( _codecContext->codec_id );
-	size_t bitRate = bitsPerSample ? _codecContext->sample_rate * _codecContext->channels * bitsPerSample : _codecContext->bit_rate;
-	return bitRate;
+
+	// return bit rate of stream
+	if( _codecContext->bit_rate )
+		return _codecContext->bit_rate;
+
+	// else get computed bit rate from our computation (warning: way to compute bit rate of PCM audio data)
+	int bitsPerSample = av_get_bits_per_sample( _codecContext->codec_id ); // 0 if unknown for the given codec
+	return _codecContext->sample_rate * _codecContext->channels * bitsPerSample;
 }
 
 size_t AudioProperties::getNbSamples() const

--- a/src/AvTranscoder/mediaProperty/AudioProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/AudioProperties.hpp
@@ -30,8 +30,8 @@ public:
 	size_t getCodecId() const;
 	size_t getSampleRate() const;
 	size_t getChannels() const;
-	size_t getBitRate() const;
-	size_t getNbSamples() const;
+	size_t getBitRate() const;  ///< 0 if unknown
+	size_t getNbSamples() const;  ///< 0 if unknown
 
 	size_t getTicksPerFrame() const;
 	Rational getTimeBase() const;

--- a/src/AvTranscoder/mediaProperty/FileProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/FileProperties.hpp
@@ -29,7 +29,7 @@ public:
 	size_t getProgramsCount() const;
 	double getStartTime() const;
 	double getDuration() const;  ///< in seconds
-	size_t getBitRate() const;
+	size_t getBitRate() const;  ///< total stream bitrate in bit/s, 0 if not available (result of a computation by ffmpeg)
 	size_t getPacketSize() const;
 
 	PropertiesMap& getMetadatas() { return _metadatas; }

--- a/src/AvTranscoder/mediaProperty/VideoProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/VideoProperties.cpp
@@ -392,7 +392,20 @@ size_t VideoProperties::getBitRate() const
 {
 	if( ! _codecContext )
 		throw std::runtime_error( "unknown codec context" );
-	return _codecContext->bit_rate;
+
+	// return bit rate of stream
+	if( _codecContext->bit_rate )
+		return _codecContext->bit_rate;
+
+	// else get computed bit rate from format and other streams
+	size_t totalBitRate = _formatContext->bit_rate;
+	for( size_t streamIndex = 0; streamIndex < _formatContext->nb_streams; ++streamIndex )
+	{
+		if( streamIndex == getStreamIndex() )
+			continue;
+		totalBitRate -= _formatContext->streams[streamIndex]->codec->bit_rate;
+	}
+	return totalBitRate;
 }
 
 size_t VideoProperties::getMaxBitRate() const

--- a/src/AvTranscoder/mediaProperty/VideoProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/VideoProperties.hpp
@@ -47,7 +47,7 @@ public:
 	size_t getStreamIndex() const { return _streamIndex; }
 	size_t getStreamId() const;
 	size_t getCodecId() const;
-	size_t getBitRate() const;  ///< in bits/s
+	size_t getBitRate() const;  ///< in bits/s (0 if not available)
 	size_t getMaxBitRate() const;
 	size_t getMinBitRate() const;
 	size_t getNbFrames() const;


### PR DESCRIPTION
Warning: can be very approximate depending on the input format (MXF...).

<!---
@huboard:{"milestone_order":87.0}
-->
