### PR TITLE
Fix mediaProperties: user doesn't deal with exceptions when getPropertiesAsMap

### DIFF
--- a/src/AvTranscoder/mediaProperty/AttachementProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/AttachementProperties.cpp
@@ -24,7 +24,7 @@ PropertiesMap AttachementProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "streamId", getStreamId() );
+	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/AudioProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/AudioProperties.cpp
@@ -40,31 +40,31 @@ std::string AudioProperties::getCodecName() const
 {
 	if( _codec && _codec->name )
 		return std::string( _codec->name );
-	return "unknown codec";
+	throw std::runtime_error( "unknown codec name" );
 }
 
 std::string AudioProperties::getCodecLongName() const
 {
 	if( _codec && _codec->long_name )
 		return std::string( _codec->long_name );
-	return "unknown codec";
+	throw std::runtime_error( "unknown codec long name" );
 }
 
 std::string AudioProperties::getSampleFormatName() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	const char* fmtName = av_get_sample_fmt_name( _codecContext->sample_fmt );
 	if( fmtName )
 		return std::string( fmtName );
-	return "unknown sample format";
+	throw std::runtime_error( "unknown sample format name" );
 }
 
 std::string AudioProperties::getSampleFormatLongName() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->sample_fmt )
 	{
@@ -93,13 +93,13 @@ std::string AudioProperties::getSampleFormatLongName() const
 		case AV_SAMPLE_FMT_NB:
 			return "number of sample formats";
 	}
-	return "unknown sample format";
+	throw std::runtime_error( "unknown sample format long name" );
 }
 
 std::string AudioProperties::getChannelLayout() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	char buf1[1024];
 	av_get_channel_layout_string( buf1, sizeof( buf1 ), -1, _codecContext->channel_layout );
@@ -109,18 +109,18 @@ std::string AudioProperties::getChannelLayout() const
 std::string AudioProperties::getChannelName() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	const char* channelName = av_get_channel_name( _codecContext->channel_layout );
 	if( channelName )
 		return std::string( channelName );
-	return "unknown channel name";
+	throw std::runtime_error( "unknown channel name" );
 }
 
 std::string AudioProperties::getChannelDescription() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 #ifdef FF_RESAMPLE_LIBRARY
 	const char* channelDescription = av_get_channel_description( _codecContext->channel_layout );
@@ -128,7 +128,7 @@ std::string AudioProperties::getChannelDescription() const
 		return std::string( channelDescription );
 	return "unknown channel description";
 #else
-	return "can't access channel description";
+	throw std::runtime_error( "can't access channel description" );
 #endif
 }
 
@@ -199,22 +199,22 @@ PropertiesMap AudioProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "streamId", getStreamId() );
-	detail::add( dataMap, "codecId", getCodecId() );
-	detail::add( dataMap, "codecName", getCodecName() );
-	detail::add( dataMap, "codecLongName", getCodecLongName() );
-	detail::add( dataMap, "sampleFormatName", getSampleFormatName() );
-	detail::add( dataMap, "sampleFormatLongName", getSampleFormatLongName() );
-	detail::add( dataMap, "sampleRate", getSampleRate() );
-	detail::add( dataMap, "bitRate", getBitRate() );
-	detail::add( dataMap, "nbSamples", getNbSamples() );
-	detail::add( dataMap, "channels", getChannels() );
-	detail::add( dataMap, "channelLayout", getChannelLayout() );
-	detail::add( dataMap, "channelName", getChannelName() );
-	detail::add( dataMap, "channelDescription", getChannelDescription() );
-	detail::add( dataMap, "ticksPerFrame", getTicksPerFrame() );
-	detail::add( dataMap, "timeBase", getTimeBase() );
-	detail::add( dataMap, "duration", getDuration() );
+	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
+	try{ detail::add( dataMap, "codecId", getCodecId() ); } catch(std::exception& e){ detail::add( dataMap, "codecId", e.what() ); }
+	try{ detail::add( dataMap, "codecName", getCodecName() ); } catch(std::exception& e){ detail::add( dataMap, "codecName", e.what() ); }
+	try{ detail::add( dataMap, "codecLongName", getCodecLongName() ); } catch(std::exception& e){ detail::add( dataMap, "codecLongName", e.what() ); }
+	try{ detail::add( dataMap, "sampleFormatName", getSampleFormatName() ); } catch(std::exception& e){ detail::add( dataMap, "sampleFormatName", e.what() ); }
+	try{ detail::add( dataMap, "sampleFormatLongName", getSampleFormatLongName() ); } catch(std::exception& e){ detail::add( dataMap, "sampleFormatLongName", e.what() ); }
+	try{ detail::add( dataMap, "sampleRate", getSampleRate() ); } catch(std::exception& e){ detail::add( dataMap, "sampleRate", e.what() ); }
+	try{ detail::add( dataMap, "bitRate", getBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "bitRate", e.what() ); }
+	try{ detail::add( dataMap, "nbSamples", getNbSamples() ); } catch(std::exception& e){ detail::add( dataMap, "nbSamples", e.what() ); }
+	try{ detail::add( dataMap, "channels", getChannels() ); } catch(std::exception& e){ detail::add( dataMap, "channels", e.what() ); }
+	try{ detail::add( dataMap, "channelLayout", getChannelLayout() ); } catch(std::exception& e){ detail::add( dataMap, "channelLayout", e.what() ); }
+	try{ detail::add( dataMap, "channelName", getChannelName() ); } catch(std::exception& e){ detail::add( dataMap, "channelName", e.what() ); }
+	try{ detail::add( dataMap, "channelDescription", getChannelDescription() ); } catch(std::exception& e){ detail::add( dataMap, "channelDescription", e.what() ); }
+	try{ detail::add( dataMap, "ticksPerFrame", getTicksPerFrame() ); } catch(std::exception& e){ detail::add( dataMap, "ticksPerFrame", e.what() ); }
+	try{ detail::add( dataMap, "timeBase", getTimeBase() ); } catch(std::exception& e){ detail::add( dataMap, "timeBase", e.what() ); }
+	try{ detail::add( dataMap, "duration", getDuration() ); } catch(std::exception& e){ detail::add( dataMap, "duration", e.what() ); }
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/AudioProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/AudioProperties.cpp
@@ -199,22 +199,22 @@ PropertiesMap AudioProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
-	try{ detail::add( dataMap, "codecId", getCodecId() ); } catch(std::exception& e){ detail::add( dataMap, "codecId", e.what() ); }
-	try{ detail::add( dataMap, "codecName", getCodecName() ); } catch(std::exception& e){ detail::add( dataMap, "codecName", e.what() ); }
-	try{ detail::add( dataMap, "codecLongName", getCodecLongName() ); } catch(std::exception& e){ detail::add( dataMap, "codecLongName", e.what() ); }
-	try{ detail::add( dataMap, "sampleFormatName", getSampleFormatName() ); } catch(std::exception& e){ detail::add( dataMap, "sampleFormatName", e.what() ); }
-	try{ detail::add( dataMap, "sampleFormatLongName", getSampleFormatLongName() ); } catch(std::exception& e){ detail::add( dataMap, "sampleFormatLongName", e.what() ); }
-	try{ detail::add( dataMap, "sampleRate", getSampleRate() ); } catch(std::exception& e){ detail::add( dataMap, "sampleRate", e.what() ); }
-	try{ detail::add( dataMap, "bitRate", getBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "bitRate", e.what() ); }
-	try{ detail::add( dataMap, "nbSamples", getNbSamples() ); } catch(std::exception& e){ detail::add( dataMap, "nbSamples", e.what() ); }
-	try{ detail::add( dataMap, "channels", getChannels() ); } catch(std::exception& e){ detail::add( dataMap, "channels", e.what() ); }
-	try{ detail::add( dataMap, "channelLayout", getChannelLayout() ); } catch(std::exception& e){ detail::add( dataMap, "channelLayout", e.what() ); }
-	try{ detail::add( dataMap, "channelName", getChannelName() ); } catch(std::exception& e){ detail::add( dataMap, "channelName", e.what() ); }
-	try{ detail::add( dataMap, "channelDescription", getChannelDescription() ); } catch(std::exception& e){ detail::add( dataMap, "channelDescription", e.what() ); }
-	try{ detail::add( dataMap, "ticksPerFrame", getTicksPerFrame() ); } catch(std::exception& e){ detail::add( dataMap, "ticksPerFrame", e.what() ); }
-	try{ detail::add( dataMap, "timeBase", getTimeBase() ); } catch(std::exception& e){ detail::add( dataMap, "timeBase", e.what() ); }
-	try{ detail::add( dataMap, "duration", getDuration() ); } catch(std::exception& e){ detail::add( dataMap, "duration", e.what() ); }
+	addProperty( dataMap, "streamId", &AudioProperties::getStreamId );
+	addProperty( dataMap, "codecId", &AudioProperties::getCodecId );
+	addProperty( dataMap, "codecName", &AudioProperties::getCodecName );
+	addProperty( dataMap, "codecLongName", &AudioProperties::getCodecLongName );
+	addProperty( dataMap, "sampleFormatName", &AudioProperties::getSampleFormatName );
+	addProperty( dataMap, "sampleFormatLongName", &AudioProperties::getSampleFormatLongName );
+	addProperty( dataMap, "sampleRate", &AudioProperties::getSampleRate );
+	addProperty( dataMap, "bitRate", &AudioProperties::getBitRate );
+	addProperty( dataMap, "nbSamples", &AudioProperties::getNbSamples );
+	addProperty( dataMap, "channels", &AudioProperties::getChannels );
+	addProperty( dataMap, "channelLayout", &AudioProperties::getChannelLayout );
+	addProperty( dataMap, "channelName", &AudioProperties::getChannelName );
+	addProperty( dataMap, "channelDescription", &AudioProperties::getChannelDescription );
+	addProperty( dataMap, "ticksPerFrame", &AudioProperties::getTicksPerFrame );
+	addProperty( dataMap, "timeBase", &AudioProperties::getTimeBase );
+	addProperty( dataMap, "duration", &AudioProperties::getDuration );
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/AudioProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/AudioProperties.hpp
@@ -47,6 +47,16 @@ public:
 	PropertiesMap getPropertiesAsMap() const;  ///< Return all audio properties as a map (name of property: value)
 
 private:
+#ifndef SWIG
+	template<typename T>
+	void addProperty( PropertiesMap& dataMap, const std::string& key, T (AudioProperties::*getter)(void) const ) const
+	{
+		try { detail::add( dataMap, key, (this->*getter)() ); }
+		catch(std::exception& e) { detail::add( dataMap, key, e.what() ); }
+	}
+#endif
+
+private:
 	const AVFormatContext* _formatContext;  ///< Has link (no ownership)
 	AVCodecContext* _codecContext;  ///< Has link (no ownership)
 	AVCodec* _codec; ///< Has link (no ownership)

--- a/src/AvTranscoder/mediaProperty/DataProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/DataProperties.cpp
@@ -33,7 +33,7 @@ PropertiesMap DataProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "streamId", getStreamId() );
+	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/FileProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/FileProperties.cpp
@@ -21,21 +21,21 @@ FileProperties::FileProperties( const FormatContext& formatContext )
 std::string FileProperties::getFilename() const
 {
 	if( ! _formatContext || ! _formatContext->filename )
-		return "unknown file name";
+		throw std::runtime_error( "unknown file name" );
 	return _formatContext->filename;
 }
 
 std::string FileProperties::getFormatName() const
 {
 	if( ! _formatContext || ! _formatContext->iformat || ! _formatContext->iformat->name )
-		return "unknown format name";
+		throw std::runtime_error( "unknown format name" );
 	return _formatContext->iformat->name;
 }
 
 std::string FileProperties::getFormatLongName() const
 {
 	if( ! _formatContext || ! _formatContext->iformat || ! _formatContext->iformat->long_name )
-		return "unknown format long name";
+		throw std::runtime_error( "unknown format long name" );
 	return _formatContext->iformat->long_name;
 }
 
@@ -133,15 +133,16 @@ PropertiesMap FileProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "filename", getFilename() );
-	detail::add( dataMap, "formatName", getFormatName() );
-	detail::add( dataMap, "formatLongName", getFormatLongName() );
+	try{ detail::add( dataMap, "filename", getFilename() ); } catch(std::exception& e){ detail::add( dataMap, "filename", e.what() ); }
+	try{ detail::add( dataMap, "formatName", getFormatName() ); } catch(std::exception& e){ detail::add( dataMap, "formatName", e.what() ); }
+	try{ detail::add( dataMap, "formatLongName", getFormatLongName() ); } catch(std::exception& e){ detail::add( dataMap, "formatLongName", e.what() ); }
 
-	detail::add( dataMap, "startTime", getStartTime() );
-	detail::add( dataMap, "duration", getDuration() );
-	detail::add( dataMap, "bitrate", getBitRate() );
-	detail::add( dataMap, "numberOfStreams", getNbStreams() );
-	detail::add( dataMap, "numberOfPrograms", getProgramsCount() );
+	try{ detail::add( dataMap, "startTime", getStartTime() ); } catch(std::exception& e){ detail::add( dataMap, "startTime", e.what() ); }
+	try{ detail::add( dataMap, "duration", getDuration() ); } catch(std::exception& e){ detail::add( dataMap, "duration", e.what() ); }
+	try{ detail::add( dataMap, "bitrate", getBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "bitrate", e.what() ); }
+	try{ detail::add( dataMap, "numberOfStreams", getNbStreams() ); } catch(std::exception& e){ detail::add( dataMap, "numberOfStreams", e.what() ); }
+	try{ detail::add( dataMap, "numberOfPrograms", getProgramsCount() ); } catch(std::exception& e){ detail::add( dataMap, "numberOfPrograms", e.what() ); }
+
 	detail::add( dataMap, "numberOfVideoStreams", getNbVideoStreams() );
 	detail::add( dataMap, "numberOfAudioStreams", getNbAudioStreams() );
 	detail::add( dataMap, "numberOfDataStreams", getNbDataStreams() );

--- a/src/AvTranscoder/mediaProperty/FileProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/FileProperties.cpp
@@ -133,15 +133,15 @@ PropertiesMap FileProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	try{ detail::add( dataMap, "filename", getFilename() ); } catch(std::exception& e){ detail::add( dataMap, "filename", e.what() ); }
-	try{ detail::add( dataMap, "formatName", getFormatName() ); } catch(std::exception& e){ detail::add( dataMap, "formatName", e.what() ); }
-	try{ detail::add( dataMap, "formatLongName", getFormatLongName() ); } catch(std::exception& e){ detail::add( dataMap, "formatLongName", e.what() ); }
+	addProperty( dataMap, "filename", &FileProperties::getFilename );
+	addProperty( dataMap, "formatName", &FileProperties::getFormatName );
+	addProperty( dataMap, "formatLongName", &FileProperties::getFormatLongName );
 
-	try{ detail::add( dataMap, "startTime", getStartTime() ); } catch(std::exception& e){ detail::add( dataMap, "startTime", e.what() ); }
-	try{ detail::add( dataMap, "duration", getDuration() ); } catch(std::exception& e){ detail::add( dataMap, "duration", e.what() ); }
-	try{ detail::add( dataMap, "bitrate", getBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "bitrate", e.what() ); }
-	try{ detail::add( dataMap, "numberOfStreams", getNbStreams() ); } catch(std::exception& e){ detail::add( dataMap, "numberOfStreams", e.what() ); }
-	try{ detail::add( dataMap, "numberOfPrograms", getProgramsCount() ); } catch(std::exception& e){ detail::add( dataMap, "numberOfPrograms", e.what() ); }
+	addProperty( dataMap, "startTime", &FileProperties::getStartTime );
+	addProperty( dataMap, "duration", &FileProperties::getDuration );
+	addProperty( dataMap, "bitrate", &FileProperties::getBitRate );
+	addProperty( dataMap, "numberOfStreams", &FileProperties::getNbStreams );
+	addProperty( dataMap, "numberOfPrograms", &FileProperties::getProgramsCount );
 
 	detail::add( dataMap, "numberOfVideoStreams", getNbVideoStreams() );
 	detail::add( dataMap, "numberOfAudioStreams", getNbAudioStreams() );

--- a/src/AvTranscoder/mediaProperty/FileProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/FileProperties.hpp
@@ -81,14 +81,8 @@ private:
 	template<typename T>
 	void addProperty( PropertiesMap& dataMap, const std::string& key, T (FileProperties::*getter)(void) const ) const
 	{
-		try
-		{
-			detail::add( dataMap, key, (this->*getter)() );
-		}
-		catch(std::exception& e)
-		{
-			detail::add( dataMap, key, e.what() );
-		}
+		try { detail::add( dataMap, key, (this->*getter)() ); }
+		catch(std::exception& e) { detail::add( dataMap, key, e.what() ); }
 	}
 #endif
 

--- a/src/AvTranscoder/mediaProperty/FileProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/FileProperties.hpp
@@ -77,6 +77,22 @@ public:
 	void clearStreamProperties();  ///< Clear all array of stream properties
 
 private:
+#ifndef SWIG
+	template<typename T>
+	void addProperty( PropertiesMap& dataMap, const std::string& key, T (FileProperties::*getter)(void) const ) const
+	{
+		try
+		{
+			detail::add( dataMap, key, (this->*getter)() );
+		}
+		catch(std::exception& e)
+		{
+			detail::add( dataMap, key, e.what() );
+		}
+	}
+#endif
+
+private:
 	const AVFormatContext* _formatContext;  ///< Has link (no ownership)
 
 	std::vector< VideoProperties > _videoStreams;  ///< Array of properties per video stream

--- a/src/AvTranscoder/mediaProperty/PixelProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/PixelProperties.cpp
@@ -28,20 +28,20 @@ void PixelProperties::init( const AVPixelFormat avPixelFormat )
 std::string PixelProperties::getPixelName() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 
 	if( _pixelDesc && _pixelDesc->name )
 		return std::string( _pixelDesc->name );
-	return "unknown pixel name";
+	throw std::runtime_error( "unknown pixel name" );
 }
 
 std::string PixelProperties::getPixelFormatName() const
 {
 	if( ! _pixelFormat )
-		throw std::runtime_error( "unable to find pixel format." ); 
+		throw std::runtime_error( "unable to find pixel format" ); 
 
 	const char* formatName = av_get_pix_fmt_name( _pixelFormat );
-	return formatName ? std::string( formatName ) : "unknown pixel format";
+	return formatName ? std::string( formatName ) : throw std::runtime_error( "unknown pixel format" );
 }
 
 size_t PixelProperties::getBitsPerPixel() const
@@ -222,79 +222,100 @@ PropertiesMap PixelProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "pixelName", getPixelName() );
-	detail::add( dataMap, "pixelFormatName", getPixelFormatName() );
-	detail::add( dataMap, "bitDepth", getBitsPerPixel() );
-	detail::add( dataMap, "nbComponents", getNbComponents() );
-	detail::add( dataMap, "chromaWidth", getChromaWidth() );
-	detail::add( dataMap, "chromaHeight", getChromaHeight() );
+	try{ detail::add( dataMap, "pixelName", getPixelName() ); } catch(std::exception& e){ detail::add( dataMap, "pixelName", e.what() ); }
+	try{ detail::add( dataMap, "pixelFormatName", getPixelFormatName() ); } catch(std::exception& e){ detail::add( dataMap, "pixelFormatName", e.what() );}
+	try{ detail::add( dataMap, "bitDepth", getBitsPerPixel() ); } catch(std::exception& e){ detail::add( dataMap, "bitDepth", getBitsPerPixel() ); }
+	try{ detail::add( dataMap, "nbComponents", getNbComponents() ); } catch(std::exception& e){ detail::add( dataMap, "nbComponents", getNbComponents() ); }
+	try{ detail::add( dataMap, "chromaWidth", getChromaWidth() ); } catch(std::exception& e){ detail::add( dataMap, "chromaWidth", getChromaWidth() ); }
+	try{ detail::add( dataMap, "chromaHeight", getChromaHeight() ); } catch(std::exception& e){ detail::add( dataMap, "chromaHeight", getChromaHeight() ); }
 
-	std::string colorComponents;
-	switch( getColorComponents() )
+	try
 	{
-		case eComponentGray:
-			colorComponents = "gray";
-			break;
-		case eComponentRgb:
-			colorComponents = "RGB";
-			break;
-		case eComponentYuvJPEG:
-			colorComponents = "YUVJPEG";
-			break;
-		case eComponentYuvA:
-			colorComponents = "YUVA";
-			break;
-		case eComponentYuv:
-			colorComponents = "YUV";
-			break;
+		std::string colorComponents;
+		switch( getColorComponents() )
+		{
+			case eComponentGray:
+				colorComponents = "gray";
+				break;
+			case eComponentRgb:
+				colorComponents = "RGB";
+				break;
+			case eComponentYuvJPEG:
+				colorComponents = "YUVJPEG";
+				break;
+			case eComponentYuvA:
+				colorComponents = "YUVA";
+				break;
+			case eComponentYuv:
+				colorComponents = "YUV";
+				break;
+		}
+		detail::add( dataMap, "colorComponents", colorComponents );
 	}
-	detail::add( dataMap, "colorComponents", colorComponents );
-
-	std::string subsampling;
-	switch( getSubsampling() )
+	catch(std::exception& e)
 	{
-		case eSubsampling440:
-			subsampling = "440";
-			break;
-		case eSubsampling422:
-			subsampling = "422";
-			break;
-		case eSubsampling420:
-			subsampling = "420";
-			break;
-		case eSubsampling411:
-			subsampling = "411";
-			break;
-		case eSubsampling410:
-			subsampling = "410";
-			break;
-		case eSubsamplingNone:
-			subsampling = "None";
-			break;
+		detail::add( dataMap, "colorComponents", e.what() );
 	}
-	detail::add( dataMap, "subsampling", subsampling );
 
-	detail::add( dataMap, "isBigEndian", isBigEndian() );
-	detail::add( dataMap, "hasAlpha", hasAlpha() );
-	detail::add( dataMap, "isPlanar", isPlanar() );
-	detail::add( dataMap, "isIndexedColors", isIndexedColors() );
-	detail::add( dataMap, "bitWiseAcked", isBitWisePacked() );
-	detail::add( dataMap, "isHardwareAccelerated", isHardwareAccelerated() );
-	detail::add( dataMap, "rgbPixel", isRgbPixelData() );
-	detail::add( dataMap, "isPseudoPaletted", isPseudoPaletted() );
-
-	std::vector<Channel> channels = getChannels();
-	for( size_t channelIndex = 0; channelIndex < channels.size(); ++channelIndex )
+	try
 	{
-		std::stringstream channelName;
-		channelName << "channel_" << channels.at( channelIndex ).id;
-	
-		std::stringstream channelValue;
-		channelValue << "chromaHeight " << channels.at( channelIndex ).chromaHeight;
-		channelValue << " - ";
-		channelValue << "bitStep " << channels.at( channelIndex ).bitStep;
+		std::string subsampling;
+		switch( getSubsampling() )
+		{
+			case eSubsampling440:
+				subsampling = "440";
+				break;
+			case eSubsampling422:
+				subsampling = "422";
+				break;
+			case eSubsampling420:
+				subsampling = "420";
+				break;
+			case eSubsampling411:
+				subsampling = "411";
+				break;
+			case eSubsampling410:
+				subsampling = "410";
+				break;
+			case eSubsamplingNone:
+				subsampling = "None";
+				break;
+		}
+		detail::add( dataMap, "subsampling", subsampling );
+	}
+	catch(std::exception& e)
+	{
+		detail::add( dataMap, "subsampling", e.what() );
+	}
 
-		detail::add( dataMap, channelName.str(), channelValue.str() );
+	try{ detail::add( dataMap, "isBigEndian", isBigEndian() ); } catch(std::exception& e){ detail::add( dataMap, "isBigEndian", e.what() ); }
+	try{ detail::add( dataMap, "hasAlpha", hasAlpha() ); } catch(std::exception& e){ detail::add( dataMap, "hasAlpha", e.what() ); }
+	try{ detail::add( dataMap, "isPlanar", isPlanar() ); } catch(std::exception& e){ detail::add( dataMap, "isPlanar", e.what() ); }
+	try{ detail::add( dataMap, "isIndexedColors", isIndexedColors() ); } catch(std::exception& e){ detail::add( dataMap, "isIndexedColors", e.what() ); }
+	try{ detail::add( dataMap, "bitWiseAcked", isBitWisePacked() ); } catch(std::exception& e){ detail::add( dataMap, "bitWiseAcked", e.what() ); }
+	try{ detail::add( dataMap, "isHardwareAccelerated", isHardwareAccelerated() ); } catch(std::exception& e){ detail::add( dataMap, "isHardwareAccelerated", e.what() ); }
+	try{ detail::add( dataMap, "rgbPixel", isRgbPixelData() ); } catch(std::exception& e){ detail::add( dataMap, "rgbPixel", e.what() ); }
+	try{ detail::add( dataMap, "isPseudoPaletted", isPseudoPaletted() ); } catch(std::exception& e){ detail::add( dataMap, "isPseudoPaletted", e.what() ); }
+
+	try
+	{
+		std::vector<Channel> channels = getChannels();
+		for( size_t channelIndex = 0; channelIndex < channels.size(); ++channelIndex )
+		{
+			std::stringstream channelName;
+			channelName << "channel_" << channels.at( channelIndex ).id;
+
+			std::stringstream channelValue;
+			channelValue << "chromaHeight " << channels.at( channelIndex ).chromaHeight;
+			channelValue << " - ";
+			channelValue << "bitStep " << channels.at( channelIndex ).bitStep;
+
+			detail::add( dataMap, channelName.str(), channelValue.str() );
+		}
+	}
+	catch(std::exception& e)
+	{
+		detail::add( dataMap, "channels", e.what() );
 	}
 
 	return dataMap;

--- a/src/AvTranscoder/mediaProperty/PixelProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/PixelProperties.cpp
@@ -47,35 +47,35 @@ std::string PixelProperties::getPixelFormatName() const
 size_t PixelProperties::getBitsPerPixel() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return av_get_bits_per_pixel( _pixelDesc );
 }
 
 size_t PixelProperties::getNbComponents() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return _pixelDesc->nb_components;
 }
 
 size_t PixelProperties::getChromaWidth() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." );
+		throw std::runtime_error( "unable to find pixel description" );
 	return _pixelDesc->log2_chroma_w;
 }
 
 size_t PixelProperties::getChromaHeight() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." );
+		throw std::runtime_error( "unable to find pixel description" );
 	return _pixelDesc->log2_chroma_h;
 }
 
 EComponentType PixelProperties::getColorComponents() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 
 	if( _pixelDesc->nb_components == 1 || _pixelDesc->nb_components == 2 )
 	{
@@ -102,7 +102,7 @@ EComponentType PixelProperties::getColorComponents() const
 ESubsamplingType PixelProperties::getSubsampling() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 
 	if( ( _pixelDesc->log2_chroma_w == 0 ) &&
 		( _pixelDesc->log2_chroma_h == 1 ) )
@@ -138,14 +138,14 @@ ESubsamplingType PixelProperties::getSubsampling() const
 bool PixelProperties::isBigEndian() const
 {	
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return ( _pixelDesc->flags & PIX_FMT_BE ) == PIX_FMT_BE;
 }
 
 bool PixelProperties::hasAlpha() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 
 #if LIBAVCODEC_VERSION_MAJOR > 53
 	return ( _pixelDesc->flags & PIX_FMT_ALPHA ) == PIX_FMT_ALPHA;
@@ -157,42 +157,42 @@ bool PixelProperties::hasAlpha() const
 bool PixelProperties::isPlanar() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return ( _pixelDesc->flags & PIX_FMT_PLANAR ) == PIX_FMT_PLANAR;
 }
 
 bool PixelProperties::isIndexedColors() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return ( _pixelDesc->flags & PIX_FMT_PAL ) == PIX_FMT_PAL;
 }
 
 bool PixelProperties::isBitWisePacked() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return ( _pixelDesc->flags & PIX_FMT_BITSTREAM ) == PIX_FMT_BITSTREAM;
 }
 
 bool PixelProperties::isHardwareAccelerated() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return ( _pixelDesc->flags & PIX_FMT_HWACCEL ) == PIX_FMT_HWACCEL;
 }
 
 bool PixelProperties::isRgbPixelData() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 	return ( _pixelDesc->flags & PIX_FMT_RGB ) == PIX_FMT_RGB;
 }
 
 bool PixelProperties::isPseudoPaletted() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 
 #if LIBAVCODEC_VERSION_MAJOR > 53
 	return ( _pixelDesc->flags & PIX_FMT_PSEUDOPAL ) == PIX_FMT_PSEUDOPAL;
@@ -204,7 +204,7 @@ bool PixelProperties::isPseudoPaletted() const
 std::vector<Channel> PixelProperties::getChannels() const
 {
 	if( ! _pixelDesc )
-		throw std::runtime_error( "unable to find pixel description." ); 
+		throw std::runtime_error( "unable to find pixel description" ); 
 
 	std::vector<Channel> channels;
 	for( size_t channel = 0; channel < (size_t)_pixelDesc->nb_components; ++channel )

--- a/src/AvTranscoder/mediaProperty/PixelProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/PixelProperties.cpp
@@ -223,12 +223,12 @@ PropertiesMap PixelProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	try{ detail::add( dataMap, "pixelName", getPixelName() ); } catch(std::exception& e){ detail::add( dataMap, "pixelName", e.what() ); }
-	try{ detail::add( dataMap, "pixelFormatName", getPixelFormatName() ); } catch(std::exception& e){ detail::add( dataMap, "pixelFormatName", e.what() );}
-	try{ detail::add( dataMap, "bitDepth", getBitsPerPixel() ); } catch(std::exception& e){ detail::add( dataMap, "bitDepth", getBitsPerPixel() ); }
-	try{ detail::add( dataMap, "nbComponents", getNbComponents() ); } catch(std::exception& e){ detail::add( dataMap, "nbComponents", getNbComponents() ); }
-	try{ detail::add( dataMap, "chromaWidth", getChromaWidth() ); } catch(std::exception& e){ detail::add( dataMap, "chromaWidth", getChromaWidth() ); }
-	try{ detail::add( dataMap, "chromaHeight", getChromaHeight() ); } catch(std::exception& e){ detail::add( dataMap, "chromaHeight", getChromaHeight() ); }
+	addProperty( dataMap, "pixelName", &PixelProperties::getPixelName );
+	addProperty( dataMap, "pixelFormatName", &PixelProperties::getPixelFormatName );
+	addProperty( dataMap, "bitDepth", &PixelProperties::getBitsPerPixel );
+	addProperty( dataMap, "nbComponents", &PixelProperties::getNbComponents );
+	addProperty( dataMap, "chromaWidth", &PixelProperties::getChromaWidth );
+	addProperty( dataMap, "chromaHeight", &PixelProperties::getChromaHeight );
 
 	try
 	{
@@ -289,14 +289,14 @@ PropertiesMap PixelProperties::getPropertiesAsMap() const
 		detail::add( dataMap, "subsampling", e.what() );
 	}
 
-	try{ detail::add( dataMap, "isBigEndian", isBigEndian() ); } catch(std::exception& e){ detail::add( dataMap, "isBigEndian", e.what() ); }
-	try{ detail::add( dataMap, "hasAlpha", hasAlpha() ); } catch(std::exception& e){ detail::add( dataMap, "hasAlpha", e.what() ); }
-	try{ detail::add( dataMap, "isPlanar", isPlanar() ); } catch(std::exception& e){ detail::add( dataMap, "isPlanar", e.what() ); }
-	try{ detail::add( dataMap, "isIndexedColors", isIndexedColors() ); } catch(std::exception& e){ detail::add( dataMap, "isIndexedColors", e.what() ); }
-	try{ detail::add( dataMap, "bitWiseAcked", isBitWisePacked() ); } catch(std::exception& e){ detail::add( dataMap, "bitWiseAcked", e.what() ); }
-	try{ detail::add( dataMap, "isHardwareAccelerated", isHardwareAccelerated() ); } catch(std::exception& e){ detail::add( dataMap, "isHardwareAccelerated", e.what() ); }
-	try{ detail::add( dataMap, "rgbPixel", isRgbPixelData() ); } catch(std::exception& e){ detail::add( dataMap, "rgbPixel", e.what() ); }
-	try{ detail::add( dataMap, "isPseudoPaletted", isPseudoPaletted() ); } catch(std::exception& e){ detail::add( dataMap, "isPseudoPaletted", e.what() ); }
+	addProperty( dataMap, "isBigEndian", &PixelProperties::isBigEndian );
+	addProperty( dataMap, "hasAlpha", &PixelProperties::hasAlpha );
+	addProperty( dataMap, "isPlanar", &PixelProperties::isPlanar );
+	addProperty( dataMap, "isIndexedColors", &PixelProperties::isIndexedColors );
+	addProperty( dataMap, "bitWiseAcked", &PixelProperties::isBitWisePacked );
+	addProperty( dataMap, "isHardwareAccelerated", &PixelProperties::isHardwareAccelerated );
+	addProperty( dataMap, "rgbPixel", &PixelProperties::isRgbPixelData );
+	addProperty( dataMap, "isPseudoPaletted", &PixelProperties::isPseudoPaletted );
 
 	try
 	{

--- a/src/AvTranscoder/mediaProperty/PixelProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/PixelProperties.hpp
@@ -84,6 +84,15 @@ public:
 private:
 	void init( const AVPixelFormat avPixelFormat );
 
+#ifndef SWIG
+	template<typename T>
+	void addProperty( PropertiesMap& dataMap, const std::string& key, T (PixelProperties::*getter)(void) const ) const
+	{
+		try { detail::add( dataMap, key, (this->*getter)() ); }
+		catch(std::exception& e) { detail::add( dataMap, key, e.what() ); }
+	}
+#endif
+
 private:
 	AVPixelFormat _pixelFormat;
 	const AVPixFmtDescriptor* _pixelDesc;  ///< Has link (no ownership)

--- a/src/AvTranscoder/mediaProperty/SubtitleProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/SubtitleProperties.cpp
@@ -24,7 +24,7 @@ PropertiesMap SubtitleProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "streamId", getStreamId() );
+	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/UnknownProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/UnknownProperties.cpp
@@ -24,7 +24,7 @@ PropertiesMap UnknownProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "streamId", getStreamId() );
+	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/VideoProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/VideoProperties.cpp
@@ -51,51 +51,54 @@ VideoProperties::VideoProperties( const FormatContext& formatContext, const size
 
 std::string VideoProperties::getCodecName() const
 {
-	if( _codecContext && _codec )
-	{
-		if( _codec->capabilities & CODEC_CAP_TRUNCATED )
-			_codecContext->flags|= CODEC_FLAG_TRUNCATED;
+	if( !_codecContext || !_codec )
+		throw std::runtime_error( "unknown codec");
 
-		if( _codec->name )
-			return std::string( _codec->name );
-	}
-	return "unknown codec";
+	if( _codec->capabilities & CODEC_CAP_TRUNCATED )
+		_codecContext->flags|= CODEC_FLAG_TRUNCATED;
+
+	if( _codec->name )
+		return std::string( _codec->name );
+
+	throw std::runtime_error( "unknown codec name" );
 }
 
 std::string VideoProperties::getCodecLongName() const
 {
-	if( _codecContext && _codec )
-	{
-		if( _codec->capabilities & CODEC_CAP_TRUNCATED )
-			_codecContext->flags|= CODEC_FLAG_TRUNCATED;
+	if( !_codecContext || !_codec )
+		throw std::runtime_error( "unknown codec");
 
-		if( _codec->long_name )
-			return std::string( _codec->long_name );
-	}
-	return "unknown codec";
+	if( _codec->capabilities & CODEC_CAP_TRUNCATED )
+		_codecContext->flags|= CODEC_FLAG_TRUNCATED;
+
+	if( _codec->long_name )
+		return std::string( _codec->long_name );
+
+	throw std::runtime_error( "unknown codec long name" );
 }
 
 std::string VideoProperties::getProfileName() const
 {
-	if( _codecContext && _codec )
-	{
-		if( _codec->capabilities & CODEC_CAP_TRUNCATED )
-			_codecContext->flags|= CODEC_FLAG_TRUNCATED;
+	if( !_codecContext || !_codec )
+		throw std::runtime_error( "unknown codec");
 
-		if( _codecContext->profile != -99 )
-		{
-			const char* profile = NULL;
-			if( ( profile = av_get_profile_name( _codec, _codecContext->profile ) ) != NULL )
-				return std::string( profile );
-		}
+	if( _codec->capabilities & CODEC_CAP_TRUNCATED )
+		_codecContext->flags|= CODEC_FLAG_TRUNCATED;
+
+	if( _codecContext->profile != -99 )
+	{
+		const char* profile = NULL;
+		if( ( profile = av_get_profile_name( _codec, _codecContext->profile ) ) != NULL )
+			return std::string( profile );
 	}
-	return "unknown profile";
+
+	throw std::runtime_error( "unknown profile" );
 }
 
 std::string VideoProperties::getColorTransfert() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->color_trc )
 	{
@@ -159,7 +162,7 @@ std::string VideoProperties::getColorTransfert() const
 std::string VideoProperties::getColorspace() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->colorspace )
 	{
@@ -204,7 +207,7 @@ std::string VideoProperties::getColorspace() const
 std::string VideoProperties::getColorRange() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->color_range )
 	{
@@ -224,7 +227,7 @@ std::string VideoProperties::getColorRange() const
 std::string VideoProperties::getColorPrimaries() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->color_primaries )
 	{
@@ -258,7 +261,7 @@ std::string VideoProperties::getColorPrimaries() const
 std::string VideoProperties::getChromaSampleLocation() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->chroma_sample_location )
 	{
@@ -286,7 +289,7 @@ std::string VideoProperties::getChromaSampleLocation() const
 std::string VideoProperties::getFieldOrder() const
 {
 	if( ! _codecContext )
-		return "unknown codec context";
+		throw std::runtime_error( "unknown codec context" );
 
 	switch( _codecContext->field_order )
 	{
@@ -587,36 +590,36 @@ PropertiesMap VideoProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	detail::add( dataMap, "streamId", getStreamId() );
-	detail::add( dataMap, "codecId", getCodecId() );
-	detail::add( dataMap, "codecName", getCodecName() );
-	detail::add( dataMap, "codecLongName", getCodecLongName() );
-	detail::add( dataMap, "profile", getProfile() );
-	detail::add( dataMap, "profileName", getProfileName() );
-	detail::add( dataMap, "level", getLevel() );
-	detail::add( dataMap, "startTimecode", getStartTimecodeString() );
-	detail::add( dataMap, "width", getWidth() );
-	detail::add( dataMap, "height", getHeight() );
-	detail::add( dataMap, "pixelAspectRatio", getSar().num / getSar().den );
-	detail::add( dataMap, "displayAspectRatio", getDar().num / getDar().den );
-	detail::add( dataMap, "dtgActiveFormat", getDtgActiveFormat() );
-	detail::add( dataMap, "colorTransfert", getColorTransfert() );
-	detail::add( dataMap, "colorspace", getColorspace() );
-	detail::add( dataMap, "colorRange", getColorRange() );
-	detail::add( dataMap, "colorPrimaries", getColorPrimaries() );
-	detail::add( dataMap, "chromaSampleLocation", getChromaSampleLocation() );
-	detail::add( dataMap, "interlaced ", isInterlaced() );
-	detail::add( dataMap, "topFieldFirst", isTopFieldFirst() );
-	detail::add( dataMap, "fieldOrder", getFieldOrder() );
-	detail::add( dataMap, "timeBase", getTimeBase() );
-	detail::add( dataMap, "duration", getDuration() );
-	detail::add( dataMap, "fps", getFps() );
-	detail::add( dataMap, "nbFrame", getNbFrames() );
-	detail::add( dataMap, "ticksPerFrame", getTicksPerFrame() );
-	detail::add( dataMap, "bitRate", getBitRate() );
-	detail::add( dataMap, "maxBitRate", getMaxBitRate() );
-	detail::add( dataMap, "minBitRate", getMinBitRate() );
-	detail::add( dataMap, "gopSize", getGopSize() );
+	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
+	try{ detail::add( dataMap, "codecId", getCodecId() ); } catch(std::exception& e){ detail::add( dataMap, "codecId", e.what() ); }
+	try{ detail::add( dataMap, "codecName", getCodecName() ); } catch(std::exception& e){ detail::add( dataMap, "codecName", e.what() ); }
+	try{ detail::add( dataMap, "codecLongName", getCodecLongName() ); } catch(std::exception& e){ detail::add( dataMap, "codecLongName", e.what() ); }
+	try{ detail::add( dataMap, "profile", getProfile() ); } catch(std::exception& e){ detail::add( dataMap, "profile", e.what() ); }
+	try{ detail::add( dataMap, "profileName", getProfileName() ); } catch(std::exception& e){ detail::add( dataMap, "profileName", e.what() ); }
+	try{ detail::add( dataMap, "level", getLevel() ); } catch(std::exception& e){ detail::add( dataMap, "level", e.what() ); }
+	try{ detail::add( dataMap, "startTimecode", getStartTimecodeString() ); } catch(std::exception& e){ detail::add( dataMap, "startTimecode", e.what() ); }
+	try{ detail::add( dataMap, "width", getWidth() ); } catch(std::exception& e){ detail::add( dataMap, "width", e.what() ); }
+	try{ detail::add( dataMap, "height", getHeight() ); } catch(std::exception& e){ detail::add( dataMap, "height", e.what() ); }
+	try{ detail::add( dataMap, "pixelAspectRatio", getSar().num / getSar().den ); } catch(std::exception& e){ detail::add( dataMap, "pixelAspectRatio", e.what() ); }
+	try{ detail::add( dataMap, "displayAspectRatio", getDar().num / getDar().den ); } catch(std::exception& e){ detail::add( dataMap, "displayAspectRatio", e.what() ); }
+	try{ detail::add( dataMap, "dtgActiveFormat", getDtgActiveFormat() ); } catch(std::exception& e){ detail::add( dataMap, "dtgActiveFormat", e.what() ); }
+	try{ detail::add( dataMap, "colorTransfert", getColorTransfert() ); } catch(std::exception& e){ detail::add( dataMap, "colorTransfert", e.what() ); }
+	try{ detail::add( dataMap, "colorspace", getColorspace() ); } catch(std::exception& e){ detail::add( dataMap, "colorspace", e.what() ); }
+	try{ detail::add( dataMap, "colorRange", getColorRange() ); } catch(std::exception& e){ detail::add( dataMap, "colorRange", e.what() ); }
+	try{ detail::add( dataMap, "colorPrimaries", getColorPrimaries() ); } catch(std::exception& e){ detail::add( dataMap, "colorPrimaries", e.what() ); }
+	try{ detail::add( dataMap, "chromaSampleLocation", getChromaSampleLocation() ); } catch(std::exception& e){ detail::add( dataMap, "chromaSampleLocation", e.what() ); }
+	try{ detail::add( dataMap, "interlaced ", isInterlaced() ); } catch(std::exception& e){ detail::add( dataMap, "interlaced", e.what() ); }
+	try{ detail::add( dataMap, "topFieldFirst", isTopFieldFirst() ); } catch(std::exception& e){ detail::add( dataMap, "topFieldFirst", e.what() ); }
+	try{ detail::add( dataMap, "fieldOrder", getFieldOrder() ); } catch(std::exception& e){ detail::add( dataMap, "fieldOrder", e.what() ); }
+	try{ detail::add( dataMap, "timeBase", getTimeBase() ); } catch(std::exception& e){ detail::add( dataMap, "timeBase", e.what() ); }
+	try{ detail::add( dataMap, "duration", getDuration() ); } catch(std::exception& e){ detail::add( dataMap, "duration", e.what() ); }
+	try{ detail::add( dataMap, "fps", getFps() ); } catch(std::exception& e){ detail::add( dataMap, "fps", e.what() ); }
+	try{ detail::add( dataMap, "nbFrame", getNbFrames() ); } catch(std::exception& e){ detail::add( dataMap, "nbFrame", e.what() ); }
+	try{ detail::add( dataMap, "ticksPerFrame", getTicksPerFrame() ); } catch(std::exception& e){ detail::add( dataMap, "ticksPerFrame", e.what() ); }
+	try{ detail::add( dataMap, "bitRate", getBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "bitRate", e.what() ); }
+	try{ detail::add( dataMap, "maxBitRate", getMaxBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "maxBitRate", e.what() ); }
+	try{ detail::add( dataMap, "minBitRate", getMinBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "minBitRate", e.what() ); }
+	try{ detail::add( dataMap, "gopSize", getGopSize() ); } catch(std::exception& e){ detail::add( dataMap, "gopSize", e.what() ); }
 
 	std::string gop;
 	for( size_t frameIndex = 0; frameIndex < _gopStructure.size(); ++frameIndex )
@@ -627,8 +630,8 @@ PropertiesMap VideoProperties::getPropertiesAsMap() const
 	detail::add( dataMap, "gop", gop );
 	//detail::add( dataMap, "isClosedGop", isClosedGop() );
 
-	detail::add( dataMap, "hasBFrames", hasBFrames() );
-	detail::add( dataMap, "referencesFrames", getReferencesFrames() );
+	try{ detail::add( dataMap, "hasBFrames", hasBFrames() ); } catch(std::exception& e){ detail::add( dataMap, "hasBFrames", e.what() ); }
+	try{ detail::add( dataMap, "referencesFrames", getReferencesFrames() ); } catch(std::exception& e){ detail::add( dataMap, "referencesFrames", e.what() ); }
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/VideoProperties.cpp
+++ b/src/AvTranscoder/mediaProperty/VideoProperties.cpp
@@ -590,36 +590,36 @@ PropertiesMap VideoProperties::getPropertiesAsMap() const
 {
 	PropertiesMap dataMap;
 
-	try{ detail::add( dataMap, "streamId", getStreamId() ); } catch(std::exception& e){ detail::add( dataMap, "streamId", e.what() ); }
-	try{ detail::add( dataMap, "codecId", getCodecId() ); } catch(std::exception& e){ detail::add( dataMap, "codecId", e.what() ); }
-	try{ detail::add( dataMap, "codecName", getCodecName() ); } catch(std::exception& e){ detail::add( dataMap, "codecName", e.what() ); }
-	try{ detail::add( dataMap, "codecLongName", getCodecLongName() ); } catch(std::exception& e){ detail::add( dataMap, "codecLongName", e.what() ); }
-	try{ detail::add( dataMap, "profile", getProfile() ); } catch(std::exception& e){ detail::add( dataMap, "profile", e.what() ); }
-	try{ detail::add( dataMap, "profileName", getProfileName() ); } catch(std::exception& e){ detail::add( dataMap, "profileName", e.what() ); }
-	try{ detail::add( dataMap, "level", getLevel() ); } catch(std::exception& e){ detail::add( dataMap, "level", e.what() ); }
-	try{ detail::add( dataMap, "startTimecode", getStartTimecodeString() ); } catch(std::exception& e){ detail::add( dataMap, "startTimecode", e.what() ); }
-	try{ detail::add( dataMap, "width", getWidth() ); } catch(std::exception& e){ detail::add( dataMap, "width", e.what() ); }
-	try{ detail::add( dataMap, "height", getHeight() ); } catch(std::exception& e){ detail::add( dataMap, "height", e.what() ); }
-	try{ detail::add( dataMap, "pixelAspectRatio", getSar().num / getSar().den ); } catch(std::exception& e){ detail::add( dataMap, "pixelAspectRatio", e.what() ); }
-	try{ detail::add( dataMap, "displayAspectRatio", getDar().num / getDar().den ); } catch(std::exception& e){ detail::add( dataMap, "displayAspectRatio", e.what() ); }
-	try{ detail::add( dataMap, "dtgActiveFormat", getDtgActiveFormat() ); } catch(std::exception& e){ detail::add( dataMap, "dtgActiveFormat", e.what() ); }
-	try{ detail::add( dataMap, "colorTransfert", getColorTransfert() ); } catch(std::exception& e){ detail::add( dataMap, "colorTransfert", e.what() ); }
-	try{ detail::add( dataMap, "colorspace", getColorspace() ); } catch(std::exception& e){ detail::add( dataMap, "colorspace", e.what() ); }
-	try{ detail::add( dataMap, "colorRange", getColorRange() ); } catch(std::exception& e){ detail::add( dataMap, "colorRange", e.what() ); }
-	try{ detail::add( dataMap, "colorPrimaries", getColorPrimaries() ); } catch(std::exception& e){ detail::add( dataMap, "colorPrimaries", e.what() ); }
-	try{ detail::add( dataMap, "chromaSampleLocation", getChromaSampleLocation() ); } catch(std::exception& e){ detail::add( dataMap, "chromaSampleLocation", e.what() ); }
-	try{ detail::add( dataMap, "interlaced ", isInterlaced() ); } catch(std::exception& e){ detail::add( dataMap, "interlaced", e.what() ); }
-	try{ detail::add( dataMap, "topFieldFirst", isTopFieldFirst() ); } catch(std::exception& e){ detail::add( dataMap, "topFieldFirst", e.what() ); }
-	try{ detail::add( dataMap, "fieldOrder", getFieldOrder() ); } catch(std::exception& e){ detail::add( dataMap, "fieldOrder", e.what() ); }
-	try{ detail::add( dataMap, "timeBase", getTimeBase() ); } catch(std::exception& e){ detail::add( dataMap, "timeBase", e.what() ); }
-	try{ detail::add( dataMap, "duration", getDuration() ); } catch(std::exception& e){ detail::add( dataMap, "duration", e.what() ); }
-	try{ detail::add( dataMap, "fps", getFps() ); } catch(std::exception& e){ detail::add( dataMap, "fps", e.what() ); }
-	try{ detail::add( dataMap, "nbFrame", getNbFrames() ); } catch(std::exception& e){ detail::add( dataMap, "nbFrame", e.what() ); }
-	try{ detail::add( dataMap, "ticksPerFrame", getTicksPerFrame() ); } catch(std::exception& e){ detail::add( dataMap, "ticksPerFrame", e.what() ); }
-	try{ detail::add( dataMap, "bitRate", getBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "bitRate", e.what() ); }
-	try{ detail::add( dataMap, "maxBitRate", getMaxBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "maxBitRate", e.what() ); }
-	try{ detail::add( dataMap, "minBitRate", getMinBitRate() ); } catch(std::exception& e){ detail::add( dataMap, "minBitRate", e.what() ); }
-	try{ detail::add( dataMap, "gopSize", getGopSize() ); } catch(std::exception& e){ detail::add( dataMap, "gopSize", e.what() ); }
+	addProperty( dataMap, "streamId", &VideoProperties::getStreamId );
+	addProperty( dataMap, "codecId", &VideoProperties::getCodecId );
+	addProperty( dataMap, "codecName", &VideoProperties::getCodecName );
+	addProperty( dataMap, "codecLongName", &VideoProperties::getCodecLongName );
+	addProperty( dataMap, "profile", &VideoProperties::getProfile );
+	addProperty( dataMap, "profileName", &VideoProperties::getProfileName );
+	addProperty( dataMap, "level", &VideoProperties::getLevel );
+	addProperty( dataMap, "startTimecode", &VideoProperties::getStartTimecodeString );
+	addProperty( dataMap, "width", &VideoProperties::getWidth );
+	addProperty( dataMap, "height", &VideoProperties::getHeight );
+	addProperty( dataMap, "pixelAspectRatio", &VideoProperties::getSar );
+	addProperty( dataMap, "displayAspectRatio", &VideoProperties::getDar );
+	addProperty( dataMap, "dtgActiveFormat", &VideoProperties::getDtgActiveFormat );
+	addProperty( dataMap, "colorTransfert", &VideoProperties::getColorTransfert );
+	addProperty( dataMap, "colorspace", &VideoProperties::getColorspace );
+	addProperty( dataMap, "colorRange", &VideoProperties::getColorRange );
+	addProperty( dataMap, "colorPrimaries", &VideoProperties::getColorPrimaries );
+	addProperty( dataMap, "chromaSampleLocation", &VideoProperties::getChromaSampleLocation );
+	addProperty( dataMap, "interlaced ", &VideoProperties::isInterlaced );
+	addProperty( dataMap, "topFieldFirst", &VideoProperties::isTopFieldFirst );
+	addProperty( dataMap, "fieldOrder", &VideoProperties::getFieldOrder );
+	addProperty( dataMap, "timeBase", &VideoProperties::getTimeBase );
+	addProperty( dataMap, "duration", &VideoProperties::getDuration );
+	addProperty( dataMap, "fps", &VideoProperties::getFps );
+	addProperty( dataMap, "nbFrame", &VideoProperties::getNbFrames );
+	addProperty( dataMap, "ticksPerFrame", &VideoProperties::getTicksPerFrame );
+	addProperty( dataMap, "bitRate", &VideoProperties::getBitRate );
+	addProperty( dataMap, "maxBitRate", &VideoProperties::getMaxBitRate );
+	addProperty( dataMap, "minBitRate", &VideoProperties::getMinBitRate );
+	addProperty( dataMap, "gopSize", &VideoProperties::getGopSize );
 
 	std::string gop;
 	for( size_t frameIndex = 0; frameIndex < _gopStructure.size(); ++frameIndex )
@@ -630,8 +630,8 @@ PropertiesMap VideoProperties::getPropertiesAsMap() const
 	detail::add( dataMap, "gop", gop );
 	//detail::add( dataMap, "isClosedGop", isClosedGop() );
 
-	try{ detail::add( dataMap, "hasBFrames", hasBFrames() ); } catch(std::exception& e){ detail::add( dataMap, "hasBFrames", e.what() ); }
-	try{ detail::add( dataMap, "referencesFrames", getReferencesFrames() ); } catch(std::exception& e){ detail::add( dataMap, "referencesFrames", e.what() ); }
+	addProperty( dataMap, "hasBFrames", &VideoProperties::hasBFrames );
+	addProperty( dataMap, "referencesFrames", &VideoProperties::getReferencesFrames );
 
 	for( size_t metadataIndex = 0; metadataIndex < _metadatas.size(); ++metadataIndex )
 	{

--- a/src/AvTranscoder/mediaProperty/VideoProperties.hpp
+++ b/src/AvTranscoder/mediaProperty/VideoProperties.hpp
@@ -92,6 +92,15 @@ private:
 	 */
 	void analyseGopStructure( IProgress& progress );
 
+#ifndef SWIG
+	template<typename T>
+	void addProperty( PropertiesMap& dataMap, const std::string& key, T (VideoProperties::*getter)(void) const ) const
+	{
+		try { detail::add( dataMap, key, (this->*getter)() ); }
+		catch(std::exception& e) { detail::add( dataMap, key, e.what() ); }
+	}
+#endif
+
 private:
 	const AVFormatContext* _formatContext;  ///< Has link (no ownership)
 	AVCodecContext* _codecContext;  ///< Has link (no ownership)

--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -342,7 +342,7 @@ bool StreamTranscoder::processRewrap()
 	assert( _inputStream  != NULL );
 	assert( _outputStream != NULL );
 	
-	LOG_INFO( "Rewrap a frame" )
+	LOG_DEBUG( "Rewrap a frame" )
 
 	CodedData data;
 	if( ! _inputStream->readNextPacket( data ) )
@@ -380,7 +380,7 @@ bool StreamTranscoder::processTranscode( const int subStreamIndex )
 	assert( _frameBuffer    != NULL );
 	assert( _transform      != NULL );
 
-	LOG_INFO( "Transcode a frame" )
+	LOG_DEBUG( "Transcode a frame" )
 
 	// check offset
 	if( _offset )


### PR DESCRIPTION
Need to avoid copy of mediaProperties.
Need to create a base class 'Properties' in order to have also a vector of Properties in FileProperties.

<!---
@huboard:{"milestone_order":84.5}
-->
