### PR TITLE
Video/Audio decoders: allocate AVFrame in constructor

### DIFF
--- a/src/AvTranscoder/decoder/AudioDecoder.cpp
+++ b/src/AvTranscoder/decoder/AudioDecoder.cpp
@@ -21,6 +21,15 @@ AudioDecoder::AudioDecoder( InputStream& inputStream )
 	: _inputStream   ( &inputStream )
 	, _frame         ( NULL )
 {
+#if LIBAVCODEC_VERSION_MAJOR > 54
+	_frame = av_frame_alloc();
+#else
+	_frame = avcodec_alloc_frame();
+#endif
+	if( _frame == NULL )
+	{
+		throw std::runtime_error( "unable to setup frame buffer" );
+	}
 }
 
 AudioDecoder::~AudioDecoder()
@@ -44,16 +53,6 @@ AudioDecoder::~AudioDecoder()
 void AudioDecoder::setup()
 {
 	_inputStream->getAudioCodec().open();
-
-#if LIBAVCODEC_VERSION_MAJOR > 54
-	_frame = av_frame_alloc();
-#else
-	_frame = avcodec_alloc_frame();
-#endif
-	if( _frame == NULL )
-	{
-		throw std::runtime_error( "unable to setup frame buffer" );
-	}
 }
 
 bool AudioDecoder::decodeNextFrame( Frame& frameBuffer )

--- a/src/AvTranscoder/decoder/VideoDecoder.cpp
+++ b/src/AvTranscoder/decoder/VideoDecoder.cpp
@@ -20,6 +20,15 @@ VideoDecoder::VideoDecoder( InputStream& inputStream )
 	: _inputStream   ( &inputStream )
 	, _frame         ( NULL )
 {
+#if LIBAVCODEC_VERSION_MAJOR > 54
+	_frame = av_frame_alloc();
+#else
+	_frame = avcodec_alloc_frame();
+#endif
+	if( _frame == NULL )
+	{
+		throw std::runtime_error( "unable to setup frame buffer" );
+	}
 }
 
 VideoDecoder::~VideoDecoder()
@@ -42,16 +51,6 @@ VideoDecoder::~VideoDecoder()
 void VideoDecoder::setup()
 {
 	_inputStream->getVideoCodec().open();
-
-#if LIBAVCODEC_VERSION_MAJOR > 54
-	_frame = av_frame_alloc();
-#else
-	_frame = avcodec_alloc_frame();
-#endif
-	if( _frame == NULL )
-	{
-		throw std::runtime_error( "unable to setup frame buffer" );
-	}
 }
 
 bool VideoDecoder::decodeNextFrame( Frame& frameBuffer )


### PR DESCRIPTION
Not safe to do it in setup (which may not be called...).

<!---
@huboard:{"milestone_order":84.125}
-->
