### PR TITLE
CMake: can generate doxygen by using 'make doc'

### DIFF
--- a/doc/code/doxyfile.in
+++ b/doc/code/doxyfile.in
@@ -38,13 +38,13 @@ PROJECT_NAME           = AvTranscoder
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1
+PROJECT_NUMBER         = @AVTRANSCODER_VERSION_MAJOR@.@AVTRANSCODER_VERSION_MINOR@.@AVTRANSCODER_VERSION_MICRO@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          =
+PROJECT_BRIEF          = C++ API for Libav / FFmpeg
 
 # With the PROJECT_LOGO tag one can specify an logo or icon that is included in
 # the documentation. The maximum height of the logo should not exceed 55 pixels
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = dist/doc/code
+OUTPUT_DIRECTORY       = @CMAKE_INSTALL_PREFIX@/share/doc
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -753,9 +753,9 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = doc/code \
-                         app \
-                         src
+INPUT                  = @PROJECT_SOURCE_DIR@/doc/code \
+                         @PROJECT_SOURCE_DIR@/app \
+                         @PROJECT_SOURCE_DIR@/src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,3 +162,17 @@ else(SWIG_FOUND)
 	message("SWIG not found, will not build python and java bindings.")
 
 endif(SWIG_FOUND)
+
+# generate API documentation with Doxygen
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+	set(doxyfile_in ${PROJECT_SOURCE_DIR}/doc/code/doxyfile.in)
+	set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+	
+	configure_file(${doxyfile_in} ${doxyfile} @ONLY)
+	add_custom_target(doc
+		COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		COMMENT "Generating API documentation with Doxygen" VERBATIM
+	)
+endif(DOXYGEN_FOUND)


### PR DESCRIPTION
* Can install doc by using: 'make install doc'.
* Note: the doc is not generate by the default target ('all').
* Fix #124