### PR TITLE
Transcoder: can call process without argument

### DIFF
--- a/src/AvTranscoder/transcoder/Transcoder.cpp
+++ b/src/AvTranscoder/transcoder/Transcoder.cpp
@@ -224,6 +224,12 @@ bool Transcoder::processFrame()
 	return true;
 }
 
+void Transcoder::process()
+{
+	NoDisplayProgress progress;
+	process( progress );
+}
+
 void Transcoder::process( IProgress& progress )
 {
 	if( _streamTranscoders.size() == 0 )

--- a/src/AvTranscoder/transcoder/Transcoder.hpp
+++ b/src/AvTranscoder/transcoder/Transcoder.hpp
@@ -120,6 +120,7 @@ public:
 	 * @see IProgress
 	 */
 	void process( IProgress& progress );
+	void process();  ///< Call process with no display of progression
 
 	/**
 	 * @param streamIndex: careful about the order of stream insertion of the Transcoder.


### PR DESCRIPTION
Default behavior is to call process with no display of progression.
Fix #116