### PR TITLE
StreamTranscoder: refactor how to get the current process case

### DIFF
--- a/src/AvTranscoder/transcoder/StreamTranscoder.cpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.cpp
@@ -315,7 +315,7 @@ void StreamTranscoder::preProcessCodecLatency()
 		return;
 
 	// set a decoder to preload generated frames
-	if( isRewrapCase() )
+	if( getProcessCase() == eProcessCaseRewrap )
 		switchToGeneratorDecoder();
 
 	while( ( latency-- ) > 0 )
@@ -334,7 +334,7 @@ bool StreamTranscoder::processFrame()
 		{
 			LOG_INFO( "End of positive offset" )
 
-			if( isTranscodeCase() )
+			if( getProcessCase() == eProcessCaseTranscode )
 				switchToInputDecoder();
 			else
 				_currentDecoder = NULL;
@@ -362,7 +362,7 @@ bool StreamTranscoder::processFrame()
 		}
  	}
 
-	if( isRewrapCase() )
+	if( getProcessCase() == eProcessCaseRewrap )
 		return processRewrap();
 
 	return processTranscode( _subStreamIndex );	
@@ -501,19 +501,14 @@ double StreamTranscoder::getDuration() const
 		return std::numeric_limits<double>::max();
 }
 
-bool StreamTranscoder::isTranscodeCase() const
+StreamTranscoder::EProcessCase StreamTranscoder::getProcessCase() const
 {
-	return _inputStream && _inputDecoder;
-}
-
-bool StreamTranscoder::isRewrapCase() const
-{
-	return _inputStream && ! _inputDecoder;
-}
-
-bool StreamTranscoder::isGeneratorCase() const
-{
-	return ! _inputStream;
+	if( _inputStream && _inputDecoder )
+		return eProcessCaseTranscode;
+	else if( _inputStream && ! _inputDecoder )
+		return eProcessCaseRewrap;
+	else
+		return eProcessCaseGenerator;
 }
 
 }

--- a/src/AvTranscoder/transcoder/StreamTranscoder.hpp
+++ b/src/AvTranscoder/transcoder/StreamTranscoder.hpp
@@ -95,9 +95,15 @@ private:
 	bool processRewrap();
 	bool processTranscode( const int subStreamIndex = -1 );  ///< By default transcode all channels
 
-	bool isTranscodeCase() const;
-	bool isRewrapCase() const;
-	bool isGeneratorCase() const;
+	//@{
+	// Get the current process case.
+	enum EProcessCase {
+	    eProcessCaseTranscode,
+	    eProcessCaseRewrap,
+	    eProcessCaseGenerator
+	};
+	EProcessCase getProcessCase() const;
+	//@}
 
 private:
 	IInputStream* _inputStream;  ///< Input stream to read next packet (has link, no ownership)


### PR DESCRIPTION
* Add EProcessCase enum.
* Add getProcessCase method.
* Remove 3 methods isTranscodeCase, isRewrapCase, isGeneratorCase.
* Fix #180